### PR TITLE
Fix CPM install script to work with the latest releases

### DIFF
--- a/scripts/Mods/cpm.sh
+++ b/scripts/Mods/cpm.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 MODS_FOLDER=/home/sdtdserver/serverfiles/Mods
-VERSION=
+VERSION=${VERSION,,}
 
 # Change DL_LINK depending on 7 days to die branch version
 if [ "${VERSION}" == 'stable' ] || [ "${VERSION}" == 'public' ]; then
-    DL_LINK=$(curl -L -s https://api.github.com/repos/Prisma501/CSMM-Patrons-Mod/releases/latest | grep -o -E "https://github.com/Prisma501/CSMM-Patrons-Mod/releases/download(.*).zip")
+    DL_LINK=$(curl -L -s https://api.github.com/repos/Prisma501/CSMM-Patrons-Mod/releases/latest | grep -o -E "https://github.com/Prisma501/CSMM-Patrons-Mod/releases/download(.*).zip" | grep -v Naiwazi)
 elif [ "${VERSION}" == 'latest_experimental' ]; then
     DL_LINK="http://illy.bz/fi/7dtd/server_fixes.tar.gz"
 elif [ "${VERSION}" == 'alpha20.7' ] || [ "${VERSION}" == 'alpha20.7' ]; then


### PR DESCRIPTION
Fixes Version detection issue.
Adds another grep to the download URL to exclude a specific zip file.

It was tested with A21 stable.