### PR TITLE
Add Alloc Fixes option for v1.0

### DIFF
--- a/scripts/Mods/alloc_fixes.sh
+++ b/scripts/Mods/alloc_fixes.sh
@@ -7,6 +7,8 @@ VERSION=${VERSION,,}
 # Change DL_LINK depending on 7 days to die branch version
 if [ "${VERSION}" == 'stable' ] || [ "${VERSION}" == 'public' ]; then
     DL_LINK="http://illy.bz/fi/7dtd/server_fixes.tar.gz"
+elif [ "${VERSION}" == 'v1.0' ]; then
+    DL_LINK="http://illy.bz/fi/7dtd/server_fixes.tar.gz"
 elif [ "${VERSION}" == 'latest_experimental' ]; then
     DL_LINK="http://illy.bz/fi/7dtd/server_fixes.tar.gz"
 elif [ "${VERSION::7}" == 'alpha21' ]; then


### PR DESCRIPTION
The `v1.0` branch is even with `public` & `latest_experimental`. https://steamdb.info/app/251570/depots/

I'm unsure if `latest_experimental` & `v1.0` should be within the same `elif`, so I put them in separate statements.