### PR TITLE
Fix URL filename extraction in mods_downloader.sh

### DIFF
--- a/scripts/Mods/mods_downloader.sh
+++ b/scripts/Mods/mods_downloader.sh
@@ -15,8 +15,13 @@ IFS=', ' read -r -a urls <<< "$MODS_URLS"
 
 # Iterate over the URLs and download/extract/copy each file
 for url in "${urls[@]}"; do
-    # Extract filename from URL
-    filename=$(basename "$url")
+    # Extract filename from the server
+    filename=$(curl -sIL "$url" | grep -i -o -E 'content-disposition:.*filename="?([^"]*)"?' | sed -E 's/.*filename="?([^"]*)"?/\1/')
+
+    # Fallback to extracting from URL if necessary
+    if [ -z "$filename" ]; then
+        filename=$(basename "${url%%\?*}")
+    fi
 
     # Download the file
     echo "INFO: Downloading $filename from $url..."


### PR DESCRIPTION
Fix cases when the url could contain query parameters (eg [gitlab links with path)](https://gitlab.com/karlgiesing/7d2d-1.0-mods/-/archive/main/7d2d-1.0-mods-main.zip?path=khzmusik_Quality_Of_Life)

The fix gets the filename from the server headers `content-disposition: attachment; filename="real_filename.zip"` and fallback to extracting using `basename` by removing the query parameter(s): `$(basename "${url%%\?*}")`