### PR TITLE
fix: WRN The open files limit is too low (1024) and may cause crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,9 @@ RUN deluser --remove-home ubuntu
 RUN adduser --home /home/sdtdserver --disabled-password --shell /bin/bash --disabled-login --gecos "" sdtdserver \
 	&& chown -R sdtdserver:sdtdserver /home/sdtdserver
 
+#Set ulimit as recommended by the game.
+RUN  echo 'sdtdserver soft nofile 10240' >> /etc/security/limits.conf
+
 ##Need use xterm for LinuxGSM##
 ENV PUID=1000 PGID=1000 \
 	START_MODE=0 \

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,5 +49,10 @@ services:
       - 8080:8080/tcp   # OPTIONAL - WEBADMIN
       - 8081:8081/tcp   # OPTIONAL - TELNET
       - 8082:8082/tcp   # OPTIONAL - WEBSERVER https://7dtd.illy.bz/wiki/Server%20fixes
+    ulimits:
+      nofile:
+        soft: "10240"
+        hard: "10240"
+
     restart: unless-stopped # INFO - NEVER USE WITH START_MODE=4 or START_MODE=0
 ```


### PR DESCRIPTION
The game can sometimes crashes with the following message, this PR applies this fix.


```
`2024-11-14T23:12:48 0.020 WRN The open files limit is too low (1024) and may cause crashes. Recommended is at least 10240. Follow these steps to increment it:
- Open /etc/security/limits.conf with a text editor: 'sudo editor /etc/security/limits.conf'
- Add or update the line: 'sdtdserver soft nofile 10240'
- Save the file and exit the editor
- Apply the changes: Log out and back in or restart the system`