### PR TITLE
fix: remove hidden characters from mod download URLs

### DIFF
--- a/scripts/Mods/mods_downloader.sh
+++ b/scripts/Mods/mods_downloader.sh
@@ -23,6 +23,9 @@ for url in "${urls[@]}"; do
         filename=$(basename "${url%%\?*}")
     fi
 
+    # clean filename: remove carriage returns and newlines, trim leading/trailing spaces
+    filename=$(echo "$filename" | tr -d '\r\n' | sed -e 's/^ *//;s/ *$//')
+
     # Download the file
     echo "INFO: Downloading $filename from $url..."
     curl "$url" -SsL -o "${filename}"


### PR DESCRIPTION
Fixes #269 

Before:

```
MODS_URLS="https://github.com/superguru/7d2d_mod_BeyondStorage2/archive/refs/heads/master.zip" ./mods_downloader.sh
 from https://github.com/superguru/7d2d_mod_BeyondStorage2/archive/refs/heads/master.zip...
INFO: Download successful: 7d2d_mod_BeyondStorage2-master.zip
WARNING: Unsupported file type. No extraction performed.
ERROR: Modinfo.xml not found in the extracted files.
 from https://github.com/superguru/7d2d_mod_BeyondStorage2/archive/refs/heads/master.zip
All downloads, extractions, and folder movements completed.
```

After:

```
$ MODS_URLS="https://github.com/superguru/7d2d_mod_BeyondStorage2/archive/refs/heads/master.zip" ./mods_downloader.sh
INFO: Downloading 7d2d_mod_BeyondStorage2-master.zip from https://github.com/superguru/7d2d_mod_BeyondStorage2/archive/refs/heads/master.zip...
INFO: Download successful: 7d2d_mod_BeyondStorage2-master.zip
INFO: Extracting 7d2d_mod_BeyondStorage2-master.zip using unzip...
INFO: Mod BeyondStorage folder moved to sdtdserver/serverfiles/Mods
All downloads, extractions, and folder movements completed.
```