### PR TITLE
Enhance updating_info.md with game update instructions

### DIFF
--- a/docs/updating_info.md
+++ b/docs/updating_info.md
@@ -17,12 +17,24 @@
   * or update a single container: `docker-compose up -d 7dtdserver`
 * You can also remove the old dangling images: `docker image prune`
 
-#Updating Info - Game files
+
+# Updating Info - Game server files
 
 ## Updating existing server to new game version
+To update your existing server to a new game server version you need to update the environment parameter `START_MODE` to `2` or `3` [See Start Modes](parameters.md#start-modes). 
 
-* Modify `docker-compose.yml`
- * Change `startmode` to 2 (Update game and stop)
- * Run `docker-compose up` and wait for files to be updated
- * Run `docker-compose down`
- * Change `startmode` to 1 (Run game
+* It is recommeneded to to revert your `START_MODE` back after a successful update.
+
+### Via Docker Run/Create
+ * Stop the running container: `docker stop 7dtdserver`
+ * Delete the container: `docker rm 7dtdserver`
+ * Recreate a new container with the same docker create parameters as instructed above (if mapped correctly to a host folder, your folders and settings will be preserved)
+ * Ensure you have changed the `START_MODE` to 3
+
+### Via Docker Compose
+* Modify your `docker-compose.yml`
+* Change `START_MODE` to 3 (Update game and run)
+* Run `docker-compose up` and wait for files to be updated
+* Stop your server, usually CTRL+C to terminate the terminal
+* Change `START_MODE` back to 1 (Run game)
+* Run `docker-compose up -d` to bring your server back up

--- a/docs/updating_info.md
+++ b/docs/updating_info.md
@@ -1,4 +1,4 @@
-# Udating Info
+# Udating Info - Docker Files
 
 ## Via Docker Run/Create
 
@@ -16,3 +16,13 @@
 * Let compose update all containers as necessary: `docker-compose up -d`
   * or update a single container: `docker-compose up -d 7dtdserver`
 * You can also remove the old dangling images: `docker image prune`
+
+#Updating Info - Game files
+
+## Updating existing server to new game version
+
+* Modify `docker-compose.yml`
+ * Change `startmode` to 2 (Update game and stop)
+ * Run `docker-compose up` and wait for files to be updated
+ * Run `docker-compose down`
+ * Change `startmode` to 1 (Run game


### PR DESCRIPTION
Added section for updating game files.

Currently the existing documentation is vague on updating an existing game server to the new version. This pr adds in documentation explaining it a bit better. 

I used these steps to upgrade to the v2.6 update.